### PR TITLE
fix: Environment Versioning

### DIFF
--- a/chisel/Cargo.toml
+++ b/chisel/Cargo.toml
@@ -23,3 +23,4 @@ rustyline = "10.0.0"
 solang-parser = "0.1.18"
 tracing = "0.1.37"
 strum = { version = "0.24.1", features = ["derive"] }
+semver = "1.0.14"


### PR DESCRIPTION
Fixes environment versioning using [semver::Version](https://docs.rs/semver/1.0.12/semver/struct.Version.html).

Also pub re-exports semver::Version in the `ChiselEnv` module.