### PR TITLE
`forge-std/Script.sol` inheritance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,6 +730,7 @@ dependencies = [
  "foundry-common",
  "foundry-config",
  "foundry-evm",
+ "lazy_static",
  "revm",
  "rustyline",
  "semver",

--- a/chisel/Cargo.toml
+++ b/chisel/Cargo.toml
@@ -42,6 +42,7 @@ revm = "2.1.0"
 eyre = "0.6.8"
 dirs = "4.0.0"
 time = { version = "0.3.15", features = ["formatting"] }
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 serial_test = "0.9.0"

--- a/chisel/README.md
+++ b/chisel/README.md
@@ -12,7 +12,7 @@ Chisel is your solution. Chisel let's you write, execute, and debug Solidity dir
 
 Once you finish testing, Chisel even lets you export your code to a new solidity file!
 
-In this sense, Chisel even serves as a project generator.
+In this sense, Chisel even serves as a Foundry script generator.
 
 ## Feature Completion
 
@@ -33,7 +33,7 @@ Chisel aims to improve upon soli, with native foundry integration by providing f
 
 - [ ] REPL functionality
   - [x] Create temporary REPL contract (in memory, or temp file?).
-    - [ ] Implement `forge-std/Test.sol` so that cheatcodes etc. can be used.
+    - [x] Implement `forge-std/Test.sol` so that cheatcodes, etc. can be used.
   - [x] Utilize foundry's `evm` module for REPL env.
     - [x] Implement network forking.
   - [ ] Import all project files / interfaces into REPL contract automatically.
@@ -43,6 +43,7 @@ Chisel aims to improve upon soli, with native foundry integration by providing f
   - [ ] Use forge fmt module to format source code when printing via the `!source` command.
 - [x] Cache REPL History
   - [x] Allow a user to save/load sessions from their Chisel history.
+    - [ ] Fix session loading bug wrt non-serializable `IntermediateOutput` component.
 - [ ] Custom commands / cmd flags
   - [x] Inspect variable
     - [ ] Inspect raw stack

--- a/chisel/src/cli.rs
+++ b/chisel/src/cli.rs
@@ -78,7 +78,7 @@ async fn main() {
                         eprintln!("{}", Paint::red(format!("{:?}", e)));
                     }
                     DispatchResult::Success(None) => { /* Do nothing */ }
-                    DispatchResult::CommandSuccess(_) => { /* Don't need to do anything here */ }
+                    DispatchResult::CommandSuccess(_) => { /* Do nothing */ }
                     DispatchResult::FileIoError(e) => eprintln!("{}", Paint::red(format!("⚒️ Chisel File IO Error - {}", e))),
                     DispatchResult::CommandFailed(msg) | DispatchResult::Failure(Some(msg)) => eprintln!("{}", Paint::red(msg)),
                     DispatchResult::Failure(None) => eprintln!("{}\nPlease Report this bug as a github issue if it persists: https://github.com/foundry-rs/foundry/issues/new/choose", Paint::red("⚒️ Unknown Chisel Error ⚒️")),

--- a/chisel/src/executor.rs
+++ b/chisel/src/executor.rs
@@ -63,7 +63,7 @@ impl SessionSource {
                         Ok((Address::zero(), ChiselResult::default()))
                     }
                 } else {
-                    Err(eyre::eyre!("Failed to find REPL contract!"))
+                    eyre::bail!("Failed to find REPL contract!")
                 }
             }
             Err(e) => Err(e),
@@ -88,22 +88,22 @@ impl SessionSource {
                         {
                             def
                         } else {
-                            return Err(eyre::eyre!("Error: `{item}` could not be found"))
+                            eyre::bail!("Error: `{item}` could not be found");
                         };
                         let ty = if let Some(ty) =
                             Type::from_expression(ty).and_then(|ty| ty.as_ethabi())
                         {
                             ty
                         } else {
-                            return Err(eyre::eyre!("Error: Identifer type currently not supported"))
+                            eyre::bail!("Error: Identifer type currently not supported");
                         };
                         let memory_offset = if let Some(offset) = stack.data().last() {
                             offset.as_usize()
                         } else {
-                            return Err(eyre::eyre!("Error: No result found"))
+                            eyre::bail!("Error: No result found");
                         };
                         if memory_offset + 32 > memory.len() {
-                            return Err(eyre::eyre!("Error: Memory size insufficient"))
+                            eyre::bail!("Error: Memory size insufficient");
                         }
                         let data = &memory.data()[memory_offset + 32..];
                         let token = match ethabi::decode(&[ty], data) {
@@ -111,17 +111,17 @@ impl SessionSource {
                                 if let Some(token) = tokens.pop() {
                                     token
                                 } else {
-                                    return Err(eyre::eyre!("Error: No tokens decoded"))
+                                    eyre::bail!("Error: No tokens decoded");
                                 }
                             }
                             Err(err) => {
-                                return Err(eyre::eyre!("Error: Could not decode ABI: {err}"))
+                                eyre::bail!("Error: Could not decode ABI: {err}")
                             }
                         };
 
                         Ok(format_token(token))
                     } else {
-                        Err(eyre::eyre!("No state present"))
+                        eyre::bail!("No state present")
                     }
                 }
                 Err(e) => Err(e),

--- a/chisel/src/executor.rs
+++ b/chisel/src/executor.rs
@@ -1,3 +1,7 @@
+//! Executor
+//!
+//! This module contains the execution logic for the [SessionSource].
+
 use crate::prelude::{ChiselResult, ChiselRunner, SessionSource};
 use core::fmt::Debug;
 use ethers::{
@@ -152,6 +156,8 @@ impl SessionSource {
             .with_cheatcodes(CheatsConfig::new(&self.config.config, &self.config.evm_opts))
             .build(backend);
 
+        // Create a [ChiselRunner] with a default balance of [U256::MAX] and
+        // the sender [Address::zero].
         ChiselRunner::new(executor, U256::MAX, Address::zero())
     }
 }

--- a/chisel/src/lib.rs
+++ b/chisel/src/lib.rs
@@ -7,22 +7,22 @@
 /// Chisel Environment Module
 pub mod session;
 
-/// REPL command dispatcher.
+/// REPL input dispatcher module
 pub mod dispatcher;
 
-/// Session Source
+/// Chisel Session Source wrapper
 pub mod session_source;
 
-/// The runner
+/// REPL contract runner
 pub mod runner;
 
-/// The executor
+/// REPL contract executor
 pub mod executor;
 
-/// A Solidity Helper module
+/// A Solidity Helper module for rustyline
 pub mod solidity_helper;
 
-/// Re-export a prelude of relevant chisel items
+/// Prelude of all chisel modules
 pub mod prelude {
     pub use crate::{dispatcher::*, runner::*, session::*, session_source::*, solidity_helper::*};
 }

--- a/chisel/src/runner.rs
+++ b/chisel/src/runner.rs
@@ -1,3 +1,8 @@
+//! ChiselRunner
+//!
+//! This module contains the `ChiselRunner` struct, which assists with deploying
+//! and calling the REPL contract on a in-memory REVM instance.
+
 use ethers::{
     prelude::{types::U256, Address},
     types::{Bytes, Log},
@@ -25,7 +30,6 @@ pub struct ChiselRunner {
 
 /// Represents the result of a Chisel REPL run
 #[derive(Debug, Default)]
-#[allow(missing_docs)] // TODO
 pub struct ChiselResult {
     /// Was the run a success?
     pub success: bool,
@@ -84,7 +88,7 @@ impl ChiselRunner {
     /// This will return _estimated_ gas instead of the precise gas the call would consume, so it
     /// can be used as `gas_limit`.
     ///
-    /// Taken directly from Forge's Script Runner
+    /// Taken from [Forge's Script Runner](https://github.com/foundry-rs/foundry/blob/master/cli/src/cmd/forge/script/runner.rs)
     fn call(
         &mut self,
         from: Address,
@@ -170,10 +174,10 @@ impl ChiselRunner {
             gas_used,
             logs,
             traces: traces
-                .map(|mut traces| {
+                .map(|traces| {
                     // Manually adjust gas for the trace to add back the stipend/real used gas
                     // TODO: For chisel, we may not want to perform this adjustment.
-                    traces.arena[0].trace.gas_cost = gas_used;
+                    // traces.arena[0].trace.gas_cost = gas_used;
                     vec![(TraceKind::Execution, traces)]
                 })
                 .unwrap_or_default(),

--- a/chisel/src/session.rs
+++ b/chisel/src/session.rs
@@ -1,3 +1,8 @@
+//! ChiselSession
+//!
+//! This module contains the `ChiselSession` struct, which is the top-level
+//! wrapper for a serializable REPL session.
+
 use crate::{prelude::SessionSource, session_source::SessionSourceConfig};
 use ethers_solc::Solc;
 use eyre::Result;

--- a/chisel/src/session.rs
+++ b/chisel/src/session.rs
@@ -186,7 +186,7 @@ impl ChiselSession {
         }
 
         if sessions.is_empty() {
-            return Err(eyre::eyre!("No sessions found!"))
+            eyre::bail!("No sessions found!")
         } else {
             // Return the list of sessions and their modified times
             Ok(sessions)

--- a/chisel/src/solidity_helper.rs
+++ b/chisel/src/solidity_helper.rs
@@ -1,3 +1,8 @@
+//! SolidityHelper
+//!
+//! This module contains the `SolidityHelper`, a [rustyline::Helper] implementation for
+//! usage in Chisel. It is ported from [soli](https://github.com/jpopesculian/soli/blob/master/src/main.rs).
+
 use crate::dispatcher::ChiselCommand;
 use rustyline::{
     completion::Completer,
@@ -14,7 +19,6 @@ use std::{borrow::Cow, str::FromStr};
 use yansi::{Color, Paint, Style};
 
 /// A rustyline helper for Solidity code
-#[allow(dead_code)]
 pub struct SolidityHelper;
 
 /// Highlighter implementation for `SolHighlighter`
@@ -28,7 +32,7 @@ impl Highlighter for SolidityHelper {
     }
 }
 
-/// Reused from [soli](https://github.com/jpopesculian/soli/blob/master/src/main.rs)
+/// Ported from [soli](https://github.com/jpopesculian/soli/blob/master/src/main.rs)
 impl SolidityHelper {
     /// Get styles for a solidity source string
     pub fn get_styles(input: &str) -> Vec<(usize, Style, usize)> {


### PR DESCRIPTION
# Overview

REPL contract now inherits `Script.sol` from `forge-std` via the `testdata` module. Elected not to go with `TempProject` due to not having a need for cached artifacts + the extra overhead that the wrapper offers.